### PR TITLE
Add Nagios check for contrail vrouter kernel module

### DIFF
--- a/contrail-agent/files/plugins/check-contrail-vrouter-kernel-mod.sh
+++ b/contrail-agent/files/plugins/check-contrail-vrouter-kernel-mod.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+MODULE_NAME="vrouter"
+
+kernelrel=$(uname -r)
+modpath=$(modinfo -n "$MODULE_NAME")
+modkernrel=$(modinfo -F vermagic "$modpath" | awk '{print $1}')
+
+if [ "$kernelrel" = "$modkernrel" ]; then
+    echo "OK";
+    exit 0;
+else
+    echo "CRITICAL";
+    exit 2;
+fi
+

--- a/contrail-agent/hooks/contrail_agent_utils.py
+++ b/contrail-agent/hooks/contrail_agent_utils.py
@@ -606,6 +606,12 @@ def update_nrpe_config():
         check_cmd=common_utils.contrail_status_cmd(MODULE, plugins_dir)
     )
 
+    nrpe_compat.add_check(
+        shortname='contrail_vrouter_kernel_mod',
+        description='Check contrail vrouter kernel mod',
+        check_cmd='check-contrail-vrouter-kernel-mod.sh'
+    )
+
     nrpe_compat.write()
 
 


### PR DESCRIPTION
Fixes: https://github.com/Juniper/contrail-charms/issues/122

Tested and confirmed to be working on top of juju charm release 22 of contrail-agent, and Docker image hub.juniper.net/contrail/contrail-vrouter-agent:1912.L2.58